### PR TITLE
chore: move ESLint ignores to config and drop .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,8 +1,0 @@
-node_modules
-android
-ios
-.expo
-.expo-shared
-dist
-build
-coverage

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,10 +1,19 @@
 // https://docs.expo.dev/guides/using-eslint/
-const { defineConfig } = require('eslint/config');
-const expoConfig = require('eslint-config-expo/flat');
+const { defineConfig } = require("eslint/config");
+const expoConfig = require("eslint-config-expo/flat");
 
 module.exports = defineConfig([
   expoConfig,
   {
-    ignores: ['dist/*'],
+    ignores: [
+      "node_modules",
+      "android",
+      "ios",
+      ".expo",
+      ".expo-shared",
+      "dist",
+      "build",
+      "coverage",
+    ],
   },
 ]);


### PR DESCRIPTION
* Mutat ignore-urile în eslint.config.js, conform ESLint v9.
* Șters .eslintignore deprecat.
* Fără schimbări în cod sau reguli.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author