### PR TITLE
chore: set Android package and iOS bundle identifier

### DIFF
--- a/app.json
+++ b/app.json
@@ -9,14 +9,16 @@
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "bundleIdentifier": "com.ninistuff.unplan"
     },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/images/adaptive-icon.png",
         "backgroundColor": "#ffffff"
       },
-      "edgeToEdgeEnabled": true
+      "edgeToEdgeEnabled": true,
+      "package": "com.ninistuff.unplan"
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
• Adăugat expo.android.package și expo.ios.bundleIdentifier
• Valoare folosită com.ninistuff.unplan
• Fără schimbări în cod

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author