### PR TITLE
chore: ignore package-lock.json in Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,3 +9,4 @@ coverage
 .out
 .nyc_output
 *.log
+package-lock.json


### PR DESCRIPTION
Exclude package-lock.json din verificarea Prettier pentru a evita alertele pe fișiere generate.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author