### PR TITLE
refactor(icon): remove `any` cast from Icon name (type-safe)

### DIFF
--- a/app/_components/Icon.tsx
+++ b/app/_components/Icon.tsx
@@ -78,5 +78,5 @@ export default function Icon({
   }
 
   // Default single icon fallback
-  return <Ionicons name={name as any} size={size} color={color} />;
+  return <Ionicons name={name} size={size} color={color} />;
 }

--- a/utils/overpass.ts
+++ b/utils/overpass.ts
@@ -15,7 +15,7 @@ export interface OSMBase {
   lat?: number;
   lon?: number;
   center?: { lat: number; lon: number };
-  geometry?: Array<{ lat: number; lon: number }>;
+  geometry?: { lat: number; lon: number }[];
 }
 
 export interface OSMNode extends OSMBase {


### PR DESCRIPTION
Context
- Parte din #25 (Reduce any în fișierele critice)
- Fișier: app/_components/Icon.tsx (linia 81)

Ce s-a schimbat
- Eliminat `name={name as any}` → `name={name}`.
- Păstrat tipul existent `AppIconName`; fără schimbări de logică/UX.

Verificări
- TypeScript: ✅ tsc --noEmit --skipLibCheck (curat)
- ESLint: ✅ --max-warnings 0 (curat)
- Pre-push Babel: ✅ (script repo)

Risc
- Low: doar strictizare de tip, fără efecte funcționale.

Relates to: #25
