### PR TITLE
refactor: extract OSRM and OTP types

### DIFF
--- a/lib/external/osrmTypes.ts
+++ b/lib/external/osrmTypes.ts
@@ -1,0 +1,37 @@
+// lib/external/osrmTypes.ts
+// Minimal types for OSRM (Open Source Routing Machine) API responses
+// Only includes fields that are actually used by the application
+
+export interface OsrmGeometry {
+  type: "LineString";
+  coordinates: [number, number][];
+}
+
+export interface OsrmRoute {
+  distance: number;
+  duration: number;
+  geometry: OsrmGeometry;
+}
+
+export interface OsrmResponse {
+  routes?: OsrmRoute[];
+  code?: string;
+  message?: string;
+}
+
+// Type guard for OSRM response validation
+export function isOsrmResponse(obj: unknown): obj is OsrmResponse {
+  if (typeof obj !== "object" || obj === null) return false;
+  const response = obj as Record<string, unknown>;
+
+  // Check if routes exists and is an array
+  if (response.routes !== undefined && !Array.isArray(response.routes)) return false;
+
+  // Check if code exists and is a string
+  if (response.code !== undefined && typeof response.code !== "string") return false;
+
+  // Check if message exists and is a string
+  if (response.message !== undefined && typeof response.message !== "string") return false;
+
+  return true;
+}

--- a/lib/external/otpTypes.ts
+++ b/lib/external/otpTypes.ts
@@ -1,0 +1,55 @@
+// lib/external/otpTypes.ts
+// Minimal types for OpenTripPlanner (OTP) API responses
+// Only includes fields that are actually used by the application
+
+export interface OtpPlace {
+  lat?: number;
+  lon?: number;
+  name?: string;
+}
+
+export interface OtpLegGeometry {
+  points?: string;
+}
+
+export interface OtpLeg {
+  mode?: string;
+  from?: OtpPlace;
+  to?: OtpPlace;
+  legGeometry?: OtpLegGeometry;
+}
+
+export interface OtpItinerary {
+  legs?: OtpLeg[];
+}
+
+export interface OtpPlan {
+  itineraries?: OtpItinerary[];
+}
+
+export interface OtpResponse {
+  error?: { msg?: string };
+  plan?: OtpPlan;
+}
+
+// Type guard for OTP response validation
+export function isOtpResponse(obj: unknown): obj is OtpResponse {
+  if (typeof obj !== "object" || obj === null) return false;
+  const response = obj as Record<string, unknown>;
+
+  // Check if error exists and has correct structure
+  if (response.error !== undefined) {
+    if (typeof response.error !== "object" || response.error === null) return false;
+    const error = response.error as Record<string, unknown>;
+    if (error.msg !== undefined && typeof error.msg !== "string") return false;
+  }
+
+  // Check if plan exists and has correct structure
+  if (response.plan !== undefined) {
+    if (typeof response.plan !== "object" || response.plan === null) return false;
+    const plan = response.plan as Record<string, unknown>;
+    if (plan.itineraries !== undefined && !Array.isArray(plan.itineraries)) return false;
+  }
+
+  return true;
+}

--- a/utils/transitRouter.ts
+++ b/utils/transitRouter.ts
@@ -1,62 +1,10 @@
 // utils/transitRouter.ts
 // utils/transitRouter.ts
 import { fetchWithTimeout } from "./fetchWithTimeout";
-
 import type { LatLng } from "../lib/planTypes";
+import type { OtpResponse } from "../lib/external/otpTypes";
+import { isOtpResponse } from "../lib/external/otpTypes";
 // import { getTransitConfig, logTransitStatus } from "./transitConfig";
-
-// Local types for OTP API responses
-interface OtpPlace {
-  lat?: number;
-  lon?: number;
-  name?: string;
-}
-
-interface OtpLegGeometry {
-  points?: string;
-}
-
-interface OtpLeg {
-  mode?: string;
-  from?: OtpPlace;
-  to?: OtpPlace;
-  legGeometry?: OtpLegGeometry;
-}
-
-interface OtpItinerary {
-  legs?: OtpLeg[];
-}
-
-interface OtpPlan {
-  itineraries?: OtpItinerary[];
-}
-
-interface OtpResponse {
-  error?: { msg?: string };
-  plan?: OtpPlan;
-}
-
-// Type guard for OTP response
-function isOtpResponse(obj: unknown): obj is OtpResponse {
-  if (typeof obj !== "object" || obj === null) return false;
-  const response = obj as Record<string, unknown>;
-
-  // Check if error exists and has correct structure
-  if (response.error !== undefined) {
-    if (typeof response.error !== "object" || response.error === null) return false;
-    const error = response.error as Record<string, unknown>;
-    if (error.msg !== undefined && typeof error.msg !== "string") return false;
-  }
-
-  // Check if plan exists and has correct structure
-  if (response.plan !== undefined) {
-    if (typeof response.plan !== "object" || response.plan === null) return false;
-    const plan = response.plan as Record<string, unknown>;
-    if (plan.itineraries !== undefined && !Array.isArray(plan.itineraries)) return false;
-  }
-
-  return true;
-}
 
 export type TransitLegKind = "foot" | "bus" | "metro";
 


### PR DESCRIPTION
Move minimal external API types to lib/external. Import in transitRouter. No logic or UI changes.

**Changes:**
- Created `lib/external/otpTypes.ts` with minimal OTP API response types
- Created `lib/external/osrmTypes.ts` with minimal OSRM API response types
- Updated `utils/transitRouter.ts` to import from shared modules
- Removed duplicate type definitions
- Added type guards for response validation

**Benefits:**
- 📚 **Reusability**: External API types can be shared across modules
- 🔒 **Type Safety**: Centralized type definitions with validation
- 🧹 **Maintainability**: Single source of truth for external API contracts
- 📄 **Documentation**: Clear separation of external vs internal types

**Impact:**
- No behavior changes
- Better code organization
- Easier to maintain API contracts

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author